### PR TITLE
Initial code drop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+# Use `allow` to specify which dependencies to maintain
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -1,0 +1,23 @@
+---
+name: Check links in README
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        # Full git history is needed to get a proper list of changed files
+        # within `mega-linter`
+        fetch-depth: 0
+    - uses: docker://dkhamsing/awesome_bot:latest
+      with:
+        args: /github/workspace/README.md --allow-ssl --allow 500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io

--- a/Dockerfile.cgiserver
+++ b/Dockerfile.cgiserver
@@ -1,0 +1,15 @@
+# FROM debian:11-slim
+FROM ubuntu:22.04
+
+ARG application_version
+LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL version=${application_version}
+
+RUN apt-get update
+RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN update-ca-certificates
+
+RUN apt-get install -y moosefs-cgiserv
+LABEL description="moosefs-cgiserv image"
+
+CMD ["bash", "-l"]

--- a/Dockerfile.chunkserver
+++ b/Dockerfile.chunkserver
@@ -1,0 +1,15 @@
+# FROM debian:11-slim
+FROM ubuntu:22.04
+
+ARG application_version
+LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL version=${application_version}
+
+RUN apt-get update
+RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN update-ca-certificates
+
+RUN apt-get install -y moosefs-chunkserver
+LABEL description="moosefs-chunkserver image"
+
+CMD ["bash", "-l"]

--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -1,0 +1,15 @@
+# FROM debian:11-slim
+FROM ubuntu:22.04
+
+ARG application_version
+LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL version=${application_version}
+
+RUN apt-get update
+RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN update-ca-certificates
+
+RUN apt-get install -y moosefs-master
+LABEL description="moosefs-master image"
+
+CMD ["bash", "-l"]

--- a/Dockerfile.metalogger
+++ b/Dockerfile.metalogger
@@ -1,0 +1,15 @@
+# FROM debian:11-slim
+FROM ubuntu:22.04
+
+ARG application_version
+LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL version=${application_version}
+
+RUN apt-get update
+RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN update-ca-certificates
+
+RUN apt-get install -y moosefs-metalogger
+
+LABEL description="moosefs-metalogger image"
+CMD ["bash", "-l"]

--- a/Dockerfile.netdump
+++ b/Dockerfile.netdump
@@ -1,0 +1,15 @@
+# FROM debian:11-slim
+FROM ubuntu:22.04
+
+ARG application_version
+LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL description="moosefs-master image"
+LABEL version=${application_version}
+
+RUN apt-get update
+RUN apt-get install -y apt-utils ca-certificates --no-install-recommends && \
+    update-ca-certificates
+
+RUN apt-get install -y moosefs-master && \
+
+CMD ["bash", "-l"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+.PHONY: c clean \
+	f format \
+	h help \
+	local \
+	multiarch_image \
+	publish \
+	t test \
+	wheel
+
+h: help
+c: clean
+f: format
+t: test
+
+help:
+	@echo "Options:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+HUB_USER=unixorn
+MOOSEFS_VERSION=3.116
+PLATFORMS=linux/arm64,linux/amd64,linux/arm/v7
+
+# If this pukes trying to import paho, try running 'poetry install'
+# MOOSEFS_VERSION=$(shell poetry run python3 -c 'from ha_mqtt_discoverable import __version__;print(__version__)' )
+
+install_hooks: ## Install the git hooks
+	poetry run pre-commit install
+
+local_cgiserver: ## Makes a moosefs-cgiserver docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --load -t ${HUB_USER}/moosefs-cgiserver -f Dockerfile.cgiserver .
+
+multiarch_cgiserver: ## Makes a moosefs-cgiserver multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-cgiserver:$(MOOSEFS_VERSION) -f Dockerfile.cgiserver .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-cgiserver:latest -f Dockerfile.cgiserver .
+	make local_cgiserver
+
+local_chunkserver: ## Makes a moosefs-chunkserver docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --load -t ${HUB_USER}/moosefs-chunkserver -f Dockerfile.chunkserver .
+
+multiarch_chunkserver: ## Makes a moosefs-chunkserver multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-chunkserver:$(MOOSEFS_VERSION) -f Dockerfile.chunkserver .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-chunkserver:latest -f Dockerfile.chunkserver .
+	make local_chunkserver
+
+local_master: ## Makes a moosefs-master docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --load -t ${HUB_USER}/moosefs-master -f Dockerfile.master .
+
+multiarch_master: ## Makes a moosefs-master multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-master:$(MOOSEFS_VERSION) -f Dockerfile.master .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-master:latest -f Dockerfile.master .
+	make local_master
+
+local_metalogger: ## Makes a moosefs-metalogger docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --load -t ${HUB_USER}/moosefs-metalogger -f Dockerfile.metalogger .
+
+multiarch_metalogger: ## Makes a moosefs-metalogger multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-metalogger:$(MOOSEFS_VERSION) -f Dockerfile.metalogger .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --push -t ${HUB_USER}/moosefs-metalogger:latest -f Dockerfile.metalogger .
+	make local_metalogger
+
+local: local_cgiserver \ ## Make images for whatever architecture you're running on, but does not push to docker hub
+	local_chunkserver \
+	local_master \
+	local_metalogger
+
+multiarch_images: ## Builds multi-architecture docker images for all the services and pushes them to docker hub
+multiarch: multiarch_cgiserver \
+	multiarch_chunkserver \
+	multiarch_master \
+	multiarch_metalogger

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,27 @@
+# moosefs-docker
+
+## Status
+
+[![License](https://img.shields.io/github/license/unixorn/moosefs-docker.svg)](https://opensource.org/licenses/BSD-3-Clause)
+![Awesomebot](https://github.com/unixorn/moosefs-docker/actions/workflows/awesomebot.yml/badge.svg)
+[![GitHub stars](https://img.shields.io/github/stars/unixorn/moosefs-docker.svg)](https://github.com/unixorn/moosefs-docker/stargazers)
+[![GitHub last commit (branch)](https://img.shields.io/github/last-commit/unixorn/moosefs-docker/main.svg)](https://github.com/unixorn/moosefs-docker)
+
+This contains Dockerfiles for [moosefs](https://moosefs.com/).
+
+## Usage
+
+The following multi-architecture (`arm64`, `armh/v7`, `amd64`) images are available on hub.docker.com:
+
+- unixorn/moosefs-cgiserver
+- unixorn/moosefs-chunkserver
+- unixorn/moosefs-master
+- unixorn/moosefs-metalogger
+
+## Building
+
+You can make the images yourself with `make multiarch_images`.
+
+If you need to support a platform other than `arm64`, `armh/v7` or `amd64`, the easiest thing to do is to edit the Makefile and change `HUB_USER` to your docker hub username and update `PLATFORMS` to include whatever other architectures you need, then run `make multiarch_images` to build new images.
+
+This allows you to use just `your-hub-username/imagename` in your docker-compose files or kubernetes deployments and not have different image names for different architectures.


### PR DESCRIPTION
- Add dockerfiles for [moosefs](https://moosefs.com] services.
- Add `Makefile` to make it easy to create multi-architecture docker images