### PR TITLE
3.117 update

### DIFF
--- a/Dockerfile.cgiserver
+++ b/Dockerfile.cgiserver
@@ -1,12 +1,11 @@
-# FROM debian:11-slim
-FROM ubuntu:22.04
+FROM debian:12-slim
 
 ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL version=${application_version}
 
-RUN apt-get update
-RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN apt-get update && \
+    apt-get install -y apt-utils ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
 RUN apt-get install -y moosefs-cgiserv

--- a/Dockerfile.chunkserver
+++ b/Dockerfile.chunkserver
@@ -1,12 +1,11 @@
-# FROM debian:11-slim
-FROM ubuntu:22.04
+FROM debian:12-slim
 
 ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL version=${application_version}
 
-RUN apt-get update
-RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN apt-get update && \
+    apt-get install -y apt-utils ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
 RUN apt-get install -y moosefs-chunkserver

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -2,13 +2,13 @@ FROM debian:12-slim
 
 ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
+LABEL description="moosefs-cli image"
 LABEL version=${application_version}
 
 RUN apt-get update && \
     apt-get install -y apt-utils ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
-RUN apt-get install -y moosefs-master
-LABEL description="moosefs-master image"
+RUN apt-get install -y moosefs-cli
 
-CMD ["/usr/sbin/mfsmaster", "start"]
+CMD ["bash", "-l"]

--- a/Dockerfile.metalogger
+++ b/Dockerfile.metalogger
@@ -1,12 +1,11 @@
-# FROM debian:11-slim
-FROM ubuntu:22.04
+FROM debian:12-slim
 
 ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL version=${application_version}
 
-RUN apt-get update
-RUN apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN apt-get update && \
+    apt-get install -y apt-utils ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
 RUN apt-get install -y moosefs-metalogger

--- a/Dockerfile.netdump
+++ b/Dockerfile.netdump
@@ -1,15 +1,14 @@
-# FROM debian:11-slim
-FROM ubuntu:22.04
+FROM debian:12-slim
 
 ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
-LABEL description="moosefs-master image"
+LABEL description="moosefs-netdump image"
 LABEL version=${application_version}
 
-RUN apt-get update
-RUN apt-get install -y apt-utils ca-certificates --no-install-recommends && \
-    update-ca-certificates
+RUN apt-get update && \
+    apt-get install -y apt-utils ca-certificates --no-install-recommends
+RUN update-ca-certificates
 
-RUN apt-get install -y moosefs-master && \
+RUN apt-get install -y moosefs-netdump
 
 CMD ["bash", "-l"]

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,8 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 HUB_USER=unixorn
-MOOSEFS_VERSION=3.116
+MOOSEFS_VERSION=3.117
 PLATFORMS=linux/arm64,linux/amd64,linux/arm/v7
-
-# If this pukes trying to import paho, try running 'poetry install'
-# MOOSEFS_VERSION=$(shell poetry run python3 -c 'from ha_mqtt_discoverable import __version__;print(__version__)' )
 
 install_hooks: ## Install the git hooks
 	poetry run pre-commit install
@@ -34,7 +31,6 @@ multiarch_cgiserver: ## Makes a moosefs-cgiserver multi-architecture docker imag
 	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-cgiserver:latest -f Dockerfile.cgiserver .
 	docker pull ${HUB_USER}/moosefs-cgiserver:latest
 
-
 local_chunkserver: ## Makes a moosefs-chunkserver docker image for only the architecture we're running on. Does not push to dockerhub.
 	docker buildx build --pull --load -t ${HUB_USER}/moosefs-chunkserver -f Dockerfile.chunkserver .
 
@@ -43,6 +39,13 @@ multiarch_chunkserver: ## Makes a moosefs-chunkserver multi-architecture docker 
 	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-chunkserver:latest -f Dockerfile.chunkserver .
 	docker pull ${HUB_USER}/moosefs-chunkserver:latest
 
+local_cli: ## Makes a moosefs-cli docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --pull --load -t ${HUB_USER}/moosefs-cli -f Dockerfile.cli .
+
+multiarch_cli: ## Makes a moosefs-cli multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-cli:$(MOOSEFS_VERSION) -f Dockerfile.cli .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-cli:latest -f Dockerfile.cli .
+	docker pull ${HUB_USER}/moosefs-cli:latest
 
 local_master: ## Makes a moosefs-master docker image for only the architecture we're running on. Does not push to dockerhub.
 	docker buildx build --pull --load -t ${HUB_USER}/moosefs-master -f Dockerfile.master .
@@ -60,13 +63,25 @@ multiarch_metalogger: ## Makes a moosefs-metalogger multi-architecture docker im
 	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-metalogger:latest -f Dockerfile.metalogger .
 	docker pull ${HUB_USER}/moosefs-metalogger:latest
 
+local_netdump: ## Makes a moosefs-netdump docker image for only the architecture we're running on. Does not push to dockerhub.
+	docker buildx build --pull --load -t ${HUB_USER}/moosefs-netdump -f Dockerfile.netdump .
+
+multiarch_netdump: ## Makes a moosefs-netdump multi-architecture docker image for linux/arm64, linux/amd64 and linux/arm/v7 and pushes it to dockerhub
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-netdump:$(MOOSEFS_VERSION) -f Dockerfile.netdump .
+	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-netdump:latest -f Dockerfile.netdump .
+	docker pull ${HUB_USER}/moosefs-netdump:latest
+
 local: local_cgiserver \ ## Make images for whatever architecture you're running on, but does not push to docker hub
 	local_chunkserver \
+	local_cli \
 	local_master \
-	local_metalogger
+	local_metalogger \
+	local_netdump
 
 multiarch_images: multiarch ## Builds multi-architecture docker images for all the services and pushes them to docker hub
 multiarch: multiarch_cgiserver \
 	multiarch_chunkserver \
+	multiarch_cli \
 	multiarch_master \
-	multiarch_metalogger
+	multiarch_metalogger \
+	multiarch_netdump

--- a/Readme.md
+++ b/Readme.md
@@ -15,8 +15,10 @@ The following multi-architecture (`arm64`, `armh/v7`, `amd64`) images are availa
 
 - unixorn/moosefs-cgiserver
 - unixorn/moosefs-chunkserver
+- unixorn/moosefs-cli
 - unixorn/moosefs-master
 - unixorn/moosefs-metalogger
+- unixorn/moosefs-netdump
 
 ## Building
 
@@ -24,4 +26,4 @@ You can make the images yourself with `make multiarch_images`.
 
 If you need to support a platform other than `arm64`, `armh/v7` or `amd64`, the easiest thing to do is to edit the Makefile and change `HUB_USER` to your docker hub username and update `PLATFORMS` to include whatever other architectures you need, then run `make multiarch_images` to build new images.
 
-This allows you to use just `your-hub-username/imagename` in your docker-compose files or kubernetes deployments and not have different image names for different architectures.
+This allows you to use `your-hub-username/imagename` in your docker-compose files or kubernetes deployments and not have to use different image names for different architectures.


### PR DESCRIPTION
- Update to moosefs 3.117
- Switch to `debian:12-slim` in Dockerfiles
- Add Dockerfiles for netdump and cli
- Update all Dockerfiles to use debian:12-slim