### PR TITLE
Remove executable bit from `Makefile`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: local
-    hooks:
-      - id: clean-up-pyc-and-pyo-files
-        name: Scrub all .pyc and .pyo files before committing
-        entry: ./.hook-scripts/clean-up-pyc-and-pyo-files
-        language: script
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,8 @@ multiarch_netdump: ## Makes a moosefs-netdump multi-architecture docker image fo
 	docker buildx build --build-arg application_version=${MOOSEFS_VERSION} --platform ${PLATFORMS} --pull --push -t ${HUB_USER}/moosefs-netdump:latest -f Dockerfile.netdump .
 	docker pull ${HUB_USER}/moosefs-netdump:latest
 
-local: local_cgiserver \ ## Make images for whatever architecture you're running on, but does not push to docker hub
-	local_chunkserver \
-	local_cli \
-	local_master \
-	local_metalogger \
-	local_netdump
+local: local_all  ## Make images for whatever architecture you're running on, but does not push to docker hub
+local_all: local_cgiserver local_chunkserver local_cli local_master local_metalogger local_netdump
 
 multiarch_images: multiarch ## Builds multi-architecture docker images for all the services and pushes them to docker hub
 multiarch: multiarch_cgiserver \


### PR DESCRIPTION
Synology Drive put an executable bit on `Makefile` and I checked it in by accident. Fix.